### PR TITLE
Fix failed prop type when using render prop

### DIFF
--- a/modules/Media.js
+++ b/modules/Media.js
@@ -7,7 +7,7 @@ class Media extends React.Component {
     children: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.func
-    ]).isRequired
+    ])
   }
 
   state = {


### PR DESCRIPTION
Thanks for building this! :stars: I saw this on Twitter yesterday, and an issue came up at work today that gave me a reason to use it!

Previously, the `children` prop was required. When using the `render` prop, `children` is not supplied. If I open the browser dev tools, I can see the tests trigger the prop type failure:

![screenshot 2016-08-04 11 02 05](https://cloud.githubusercontent.com/assets/1709537/17407174/5b2f91ae-5a34-11e6-918d-5c0871f0250e.png)

This PR removes `isRequired` from the `children` prop.

I'm not familiar with a way to assert that no prop type failures occur from within tests, but I'd be happy to add that if pointed in the right direction. :+1: