### PR TITLE
PropType for array of objects on query

### DIFF
--- a/modules/Media.js
+++ b/modules/Media.js
@@ -44,7 +44,8 @@ if (__DEV__) {
   Media.propTypes = {
     query: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.object
+      PropTypes.object,
+      PropTypes.arrayOf(PropTypes.object.isRequired)
     ]).isRequired,
     render: PropTypes.func,
     children: PropTypes.oneOfType([


### PR DESCRIPTION
According to [`js2mq` docs](https://github.com/akiran/json2mq/blob/master/README.md#usage), arrays of objects are allowed too.

This PR will avoid wrong development warnings.