### PR TITLE
allow ^0.14.7, tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run lint && karma start"
   },
   "peerDependencies": {
-    "react": "15.x"
+    "react": "15.x || ^0.14.7 "
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -42,8 +42,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^3.0.0",
     "pretty-bytes": "^4.0.2",
-    "react": "^15.4.1",
-    "react-dom": "^15.3.0",
+    "react": "^15.4.1 || ^0.14.7",
+    "react-dom": "^15.3.0 || ^0.14.7",
     "readline-sync": "^1.4.4",
     "webpack": "^1.13.1"
   },


### PR DESCRIPTION
I reran the tests using `0.14.7`  (adjusted the dev dependencies) all passed.