### PR TITLE
Fixed PropTypes deprecation of React 15.5

### DIFF
--- a/modules/Media.js
+++ b/modules/Media.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import json2mq from 'json2mq'
 
 const queryType = PropTypes.oneOfType([

--- a/modules/Media.js
+++ b/modules/Media.js
@@ -13,6 +13,7 @@ const queryType = PropTypes.oneOfType([
  */
 class Media extends React.Component {
   static propTypes = {
+    defaultMatches: PropTypes.bool,
     query: queryType,
     queries: PropTypes.objectOf(queryType),
     render: PropTypes.func,
@@ -69,7 +70,7 @@ class Media extends React.Component {
 
     if (queries) {
       queries = Object.keys(queries).map(mq => ({
-        name: mq, 
+        name: mq,
         qs: json2mq(queries[mq]),
       }))
       this.queries = queries.map(mq => ({

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "karma start --single-run"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.8",
+    "prop-types": ">=15",
     "react": ">=15"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "test": "karma start --single-run"
   },
   "peerDependencies": {
-    "prop-types": ">=15",
-    "react": ">=15"
+    "react": ">=15 || ^0.14.7"
   },
   "dependencies": {
-    "json2mq": "^0.2.0"
+    "json2mq": "^0.2.0",
+    "prop-types": ">=15"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -49,9 +49,8 @@
     "karma-webpack": "^2.0.1",
     "mocha": "^3.0.0",
     "pretty-bytes": "^4.0.2",
-    "prop-types": "^15.5.8",
-    "react": "^15.4.1",
-    "react-dom": "^15.3.0",
+    "react": "^15.4.1 || ^0.14.7",
+    "react-dom": "^15.3.0 || ^0.14.7",
     "readline-sync": "^1.4.4",
     "webpack": "^1.13.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "karma start --single-run"
   },
   "peerDependencies": {
-    "react": ">=15 || ^0.14.7"
+    "prop-types": "^15.5.8",
+    "react": ">=15"
   },
   "dependencies": {
     "json2mq": "^0.2.0"
@@ -48,8 +49,9 @@
     "karma-webpack": "^2.0.1",
     "mocha": "^3.0.0",
     "pretty-bytes": "^4.0.2",
-    "react": "^15.4.1 || ^0.14.7",
-    "react-dom": "^15.3.0 || ^0.14.7",
+    "prop-types": "^15.5.8",
+    "react": "^15.4.1",
+    "react-dom": "^15.3.0",
     "readline-sync": "^1.4.4",
     "webpack": "^1.13.1"
   },


### PR DESCRIPTION
- Moreover, fixed small linting issue of `defaultMatches` not having propType