### PR TITLE
Implement two-pass render (closes #81)

### DIFF
--- a/modules/__tests__/Media-test.js
+++ b/modules/__tests__/Media-test.js
@@ -291,4 +291,20 @@ describe("A <Media> in browser environment", () => {
       });
     });
   });
+
+  describe("when defaultMatches have been passed", () => {
+    beforeEach(() => {
+      window.matchMedia = createMockMediaMatcher(false);
+    });
+
+    it("initially overwrites defaultMatches with matches from matchMedia", async () => {
+      const element = <Media queries={{ matches: "" }} defaultMatches={{ matches: true }}>
+        {({ matches }) => matches ? <div>fully matched</div> : <div>not matched</div>}
+      </Media>;
+
+      ReactDOM.render(element, node, () => {
+        expect(node.firstChild.innerHTML).toMatch('not matched');
+      });
+    });
+  })
 });

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-react": "^6.0.0",
     "gzip-size": "^3.0.0",
-    "jest": "^20.0.4",
+    "jest": "^23.5.0",
     "pascal-case": "^2.0.1",
     "pretty-bytes": "^4.0.2",
     "react": "^15.4.1 || ^0.14.7",


### PR DESCRIPTION
This is my first stab at implementing the two-pass render as described in #81.

It replaces `componentWillMount` for `componentDidMount`, which should address [SSR related issues outlined in #91](https://github.com/ReactTraining/react-media/issues/91#issuecomment-417212306). As well as prepares for the [deprecation of `componentWillMount`](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html).

It has an optimization for the "basic" case; if `defaultMatches` is not specified, it will _not_ trigger the two-pass render. So you'll only incur the additional two-pass render cost if you actually specify `defaultMatches` for SSR, in which case the two-pass is actually recommended by the React team.

@mjackson I'd really appreciate a review before merging it in. Also, I've decided to build this on top of `@next`, just so I don't have to write it twice. If you prefer to have this backported into v1, I can look into that.

Cheers!