### PR TITLE
Add missing `types` field on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "cjs/react-media.js",
   "module": "esm/react-media.js",
   "unpkg": "umd/react-media.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "node ./scripts/build.js",
     "prepublishOnly": "node ./scripts/build.js",


### PR DESCRIPTION
Hi, Thank you for awesome package :smiley:

I have one problem.
I can't import `react-media` package.
This PR is resolves to it.

As described in the following document, I changed the type so that the type is resolved correctly by adding the `types` field to `package.json`.

**Document:**
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

```json
{
  ...
  "main": "cjs/react-media.js",
  "module": "esm/react-media.js",
  "unpkg": "umd/react-media.js",
  "types": "index.d.ts",
  ...
}
```

Thank you :dog2: