### PR TITLE
Fix typo in CHANGES.md file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,11 @@
-## [v1.9.0]
+## [v1.8.0]
 > INSERT DATE
 
 - Add Typescript definitions [#76](https://github.com/ReactTraining/react-media/pull/76)
 - Add `onChange` callback [#95](https://github.com/ReactTraining/react-media/pull/95)
 - Add workaround for Safari not clearing up event handlers properly [#101](https://github.com/ReactTraining/react-media/pull/101)
 
-[v1.9.0]: https://github.com/ReactTraining/react-media/compare/v1.7.0...v1.9.0
+[v1.8.0]: https://github.com/ReactTraining/react-media/compare/v1.7.0...v1.8.0
 
 ## [v1.7.0]
 > Feb 1, 2018

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## [v1.8.0]
-> INSERT DATE
+> Feb 8, 2018
 
 - Add Typescript definitions [#76](https://github.com/ReactTraining/react-media/pull/76)
 - Add `onChange` callback [#95](https://github.com/ReactTraining/react-media/pull/95)


### PR DESCRIPTION
Lastest version was indicating v1.9.0 in CHANGES.md, but v1.8.0 is the current latest tag.