### PR TITLE
Remove react prop-types for production build (fix)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,9 +9,6 @@
     "plugin:import/errors",
     "plugin:react/recommended"
   ],
-  "globals": {
-    "__DEV__": true
-  },
   "settings": {
     "react": {
       "version": "15"

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-media.js": {
-    "bundled": 3856,
-    "minified": 2318,
-    "gzipped": 885,
+    "bundled": 3448,
+    "minified": 1966,
+    "gzipped": 769,
     "treeshaked": {
       "rollup": {
-        "code": 1928,
-        "import_statements": 272
+        "code": 1684,
+        "import_statements": 246
       },
       "webpack": {
-        "code": 3186
+        "code": 2881
       }
     }
   },
   "umd/react-media.js": {
-    "bundled": 34826,
-    "minified": 10989,
-    "gzipped": 3946
+    "bundled": 34789,
+    "minified": 10978,
+    "gzipped": 3939
   },
   "umd/react-media.min.js": {
-    "bundled": 11533,
-    "minified": 4294,
-    "gzipped": 1936
+    "bundled": 6693,
+    "minified": 2852,
+    "gzipped": 1308
   }
 }

--- a/modules/Media.js
+++ b/modules/Media.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import invariant from 'invariant';
-import json2mq from 'json2mq';
+import React from "react";
+import PropTypes from "prop-types";
+import invariant from "invariant";
+import json2mq from "json2mq";
 
-import MediaQueryList from './MediaQueryList';
+import MediaQueryList from "./MediaQueryList";
 
 /**
  * Conditionally renders based on whether or not a media query matches.
@@ -29,17 +29,17 @@ class Media extends React.Component {
   };
 
   componentWillMount() {
-    if (typeof window !== 'object') return;
+    if (typeof window !== "object") return;
 
     const targetWindow = this.props.targetWindow || window;
 
     invariant(
-      typeof targetWindow.matchMedia === 'function',
-      '<Media targetWindow> does not support `matchMedia`.'
+      typeof targetWindow.matchMedia === "function",
+      "<Media targetWindow> does not support `matchMedia`."
     );
 
     let { query } = this.props;
-    if (typeof query !== 'string') query = json2mq(query);
+    if (typeof query !== "string") query = json2mq(query);
 
     this.mediaQueryList = new MediaQueryList(
       targetWindow,
@@ -62,30 +62,28 @@ class Media extends React.Component {
         ? render()
         : null
       : children
-        ? typeof children === 'function'
-          ? children(matches)
-          : !Array.isArray(children) || children.length // Preact defaults to empty children array
-            ? matches
-              ? React.Children.only(children)
-              : null
-            : null
-        : null;
+      ? typeof children === "function"
+        ? children(matches)
+        : !Array.isArray(children) || children.length // Preact defaults to empty children array
+        ? matches
+          ? React.Children.only(children)
+          : null
+        : null
+      : null;
   }
 }
 
-if (__DEV__) {
-  Media.propTypes = {
-    defaultMatches: PropTypes.bool,
-    query: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object,
-      PropTypes.arrayOf(PropTypes.object.isRequired)
-    ]).isRequired,
-    render: PropTypes.func,
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-    targetWindow: PropTypes.object,
-    onChange: PropTypes.func
-  };
-}
+Media.propTypes = {
+  defaultMatches: PropTypes.bool,
+  query: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.arrayOf(PropTypes.object.isRequired)
+  ]).isRequired,
+  render: PropTypes.func,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  targetWindow: PropTypes.object,
+  onChange: PropTypes.func
+};
 
 export default Media;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,6 +1798,12 @@
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.21.tgz",
+      "integrity": "sha512-+gQBtcnEhYFbMPFGr8YL7SHD4BpHifFDGEc+ES0+1iDwC9psist2+eumcLoHjBMumL7N/HI/G64XR5aQC8Nr5Q==",
+      "dev": true
+    },
     "babel-preset-jest": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "babel-plugin-dev-expression": "^0.2.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.21",
     "eslint": "^5.9.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^22.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,8 @@ const cjs = [
     external,
     plugins: [
       babel({
-        exclude: /node_modules/
+        exclude: /node_modules/,
+        plugins: [['transform-react-remove-prop-types', { removeImport: true }]]
       }),
       replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
       uglify()
@@ -50,7 +51,7 @@ const esm = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
-        plugins: [['@babel/transform-runtime', { useESModules: true }]]
+        plugins: [['@babel/transform-runtime', { useESModules: true }], ['transform-react-remove-prop-types', { removeImport: true }]]
       }),
       sizeSnapshot()
     ]
@@ -97,7 +98,7 @@ const umd = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
-        plugins: [['@babel/transform-runtime', { useESModules: true }]]
+        plugins: [['@babel/transform-runtime', { useESModules: true }], ['transform-react-remove-prop-types', { removeImport: true }]]
       }),
       nodeResolve(),
       commonjs({


### PR DESCRIPTION
Since react-media **1.9.0** and adding the `__DEV__` boolean global, there is a problem in the final production build.
When importing the lib in your project an error occurred :
```shell
ReferenceError: __DEV__ is not defined
```

I use `babel-plugin-transform-react-remove-prop-types` to remove react `prop-types`in production instead of using the `__DEV__` global.

