### PR TITLE
Remove incorrect react-responsive comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,6 @@ initialState = {
 
 An optional `targetWindow` prop can be specified if you want the `query` to be evaluated against a different window object than the one the code is running in. This can be useful if you are rendering part of your component tree to an iframe or [a popup window](https://hackernoon.com/using-a-react-16-portal-to-do-something-cool-2a2d627b0202). See [this PR thread](https://github.com/ReactTraining/react-media/pull/78) for context.
 
-## Compared to react-responsive
-
-If you're curious about how react-media differs from [react-responsive](https://github.com/contra/react-responsive), please see [this comment](https://github.com/ReactTraining/react-media/issues/70#issuecomment-347774260).
-
 ## About
 
 `react-media` is developed and maintained by [React Training](https://reacttraining.com). If you're interested in learning more about what React can do for your company, please [get in touch](mailto:hello@reacttraining.com)!


### PR DESCRIPTION
I've been seeing [this comment](https://github.com/ReactTraining/react-media/issues/70#issuecomment-347774260) circulate recently, which is incorrect. react-responsive supports render functions just fine ([documented here](https://github.com/contra/react-responsive#rendering-with-a-child-function)). This behavior was added in 2016 via [this PR](https://github.com/contra/react-responsive/pull/64) so it isn't a recent addition.

Not trying to be a jerk here - I don't really care which module people use, but please don't spread misinformation as it just confuses people.

Thanks.