### PR TITLE
deprecated addListener and removeListener update

### DIFF
--- a/modules/MediaQueryList.js
+++ b/modules/MediaQueryList.js
@@ -12,12 +12,12 @@ export default class MediaQueryList {
         listener(...args);
       }
     };
-    this.nativeMediaQueryList.addListener(this.cancellableListener);
+    this.nativeMediaQueryList.addEventListener("change", this.cancellableListener);
     this.matches = this.nativeMediaQueryList.matches;
   }
 
   cancel() {
     this.active = false;
-    this.nativeMediaQueryList.removeListener(this.cancellableListener);
+    this.nativeMediaQueryList.removeEventListener("change", this.cancellableListener);
   }
 }

--- a/modules/__tests__/Media-test.js
+++ b/modules/__tests__/Media-test.js
@@ -6,8 +6,8 @@ import { renderStrict, serverRenderStrict } from './utils';
 function createMockMediaMatcher(matches) {
   return () => ({
     matches,
-    addListener: () => {},
-    removeListener: () => {}
+    addEventListener: () => {},
+    removeEventListener: () => {}
   });
 }
 


### PR DESCRIPTION
`addListener` and `removeListener` are [deprecated](https://github.com/microsoft/TypeScript/blob/602966ba4ecd0ef7923be61806b98755e2919501/lib/lib.dom.d.ts#L10380) in a favor of `addEventListener` and `removeEventListener`.

From [MediaQueryList/addListener](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener)
> This (addListener) is basically an alias for EventTarget.addEventListener(), for backwards compatibility purposes.

They are supported by all major browsers: [EventTarget/addEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)

BTW, `TSLint` is producing the following error when trying to use `addListener`:
```
ERROR: /app/Component.tsx:xx:xx - addListener is deprecated.
```