### PR TITLE
Part of #150 : add typings for useMedia

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,5 +62,8 @@ export type SingleQueryProps = BaseProps & {
 export default function Media(props: SingleQueryProps): React.ReactElement;
 export default function Media<Q>(props: MultiQueryProps<Q>): React.ReactElement;
 
-type UseMediaProps<Q> = SingleQueryProps | MultiQueryProps<Q>;
-export function useMedia<Q>(props: UseMediaProps<Q>): QueryResults<Q>;
+type UseMediaSingleQueryProps = Omit<SingleQueryProps, 'render' | 'children'>
+type UseMediaMultiQueryProps<Q> = Omit<MultiQueryProps<Q>, 'render' | 'children'>
+
+export function useMedia(props: SingleQueryProps): boolean;
+export function useMedia<Q>(props: UseMediaMultiQueryProps<Q>): QueryResults<Q>;


### PR DESCRIPTION
see https://github.com/ReactTraining/react-media/issues/150

works fine for me : 

![image](https://user-images.githubusercontent.com/7466144/84270643-47840800-ab2b-11ea-9c21-16d3a9a8dad0.png)

![image](https://user-images.githubusercontent.com/7466144/84270591-389d5580-ab2b-11ea-9fb4-f3ec220f18e3.png)

![image](https://user-images.githubusercontent.com/7466144/84272283-80bd7780-ab2d-11ea-9f6b-6dcbfac4f2de.png)


**remark : with single query, we have to use the generic to type the result :** 

![image](https://user-images.githubusercontent.com/7466144/84272425-acd8f880-ab2d-11ea-9030-2aeb5d95ecf2.png)



if not, result is typed unknown, TS seems unable to pick the first signature

![image](https://user-images.githubusercontent.com/7466144/84271258-2b349b00-ab2c-11ea-9ddc-bc87d41c0430.png)

