### PR TITLE
docs: remove useless variable in 2nd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,6 @@ With single query :
 ```tsx
 import { useMedia } from 'react-media';
 
-const GLOBAL_MEDIA_QUERIES = {
-    small: "(max-width: 599px)",
-    medium: "(min-width: 600px) and (max-width: 1199px)",
-    large: "(min-width: 1200px)"
-};
-
 const isSmallScreen = useMedia({ query: "(max-width: 599px)" });
 
 ```


### PR DESCRIPTION
This variable is not used in the example, I forget to remove it in my previous PR, it could be confusing.